### PR TITLE
build: Remove unneeded exports for functions

### DIFF
--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -104,7 +104,6 @@ function aospremote() {
     git remote add aosp https://android.googlesource.com/$PFX$PROJECT
     echo "Remote 'aosp' created"
 }
-export -f aospremote
 
 function cafremote()
 {
@@ -124,4 +123,3 @@ function cafremote()
     git remote add caf https://source.codeaurora.org/quic/la/$PFX$PROJECT
     echo "Remote 'caf' created"
 }
-export -f cafremote


### PR DESCRIPTION
* Causes warnings upon running ". build/envsetup.sh".

Signed-off-by: nysascape <nysadev@raphielgang.org>